### PR TITLE
feat: add pan video maker

### DIFF
--- a/images/camera.svg
+++ b/images/camera.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M23 19V7a2 2 0 0 0-2-2h-3.17a2 2 0 0 1-1.41-.59L14.59 2.59A2 2 0 0 0 13.17 2H8a2 2 0 0 0-2 2v1H3a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h18a2 2 0 0 0 2-2z"/>
+  <circle cx="12" cy="13" r="4"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -124,6 +124,59 @@
                         </button>
                     </div>
                 </div>
+
+                <!-- Pan Video Maker -->
+                <div class="video-maker" id="video-maker">
+                    <details>
+                        <summary class="video-summary">
+                            <img src="images/camera.svg" alt="" width="20" height="20">
+                            <span>Video</span>
+                        </summary>
+                        <div class="video-settings">
+                            <div class="setting">
+                                <label for="video-duration">Duration <span id="duration-value">15s</span></label>
+                                <input type="range" id="video-duration" min="5" max="180" value="15">
+                            </div>
+                            <div class="setting">
+                                <label for="video-fps">FPS <span id="fps-value">30</span></label>
+                                <input type="range" id="video-fps" min="30" max="120" step="30" value="30">
+                            </div>
+                            <div class="setting">
+                                <label for="video-bitrate">Bitrate <span id="bitrate-value">25</span> Mbps</label>
+                                <input type="range" id="video-bitrate" min="25" max="100" step="5" value="25">
+                            </div>
+                            <div class="setting">
+                                <label for="video-easing">Animation Easing</label>
+                                <select id="video-easing">
+                                    <option value="linear">linear</option>
+                                    <option value="ease-in-out">ease-in-out</option>
+                                    <option value="smooth">smooth</option>
+                                    <option value="ease-out">ease-out</option>
+                                </select>
+                            </div>
+                            <div class="setting">
+                                <label>Pan Direction</label>
+                                <div id="pan-direction" class="pan-grid">
+                                    <button type="button" class="dir-btn active" data-dir="ltr">L to R</button>
+                                    <button type="button" class="dir-btn" data-dir="rtl">R to L</button>
+                                    <button type="button" class="dir-btn" data-dir="lrl">L-R-L</button>
+                                    <button type="button" class="dir-btn" data-dir="rlr">R-L-R</button>
+                                </div>
+                            </div>
+                            <div class="setting">
+                                <label>Format</label>
+                                <div id="video-format" class="format-select">
+                                    <button type="button" class="fmt-btn active" data-format="mp4">MP4</button>
+                                    <button type="button" class="fmt-btn" data-format="webm">WebM</button>
+                                </div>
+                            </div>
+                            <div class="actions">
+                                <button id="generate-video" class="primary-btn">Generate Video</button>
+                            </div>
+                            <div id="video-result" class="video-result"></div>
+                        </div>
+                    </details>
+                </div>
             </section>
         </main>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -783,3 +783,76 @@ footer {
         justify-content: space-between;
     }
 }
+
+/* Pan Video Maker styles */
+.video-maker {
+    margin-top: 40px;
+}
+
+.video-maker details {
+    background: var(--surface);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+}
+
+.video-summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 15px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 600;
+}
+
+.video-settings {
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.video-settings .setting label {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+
+.video-settings input[type="range"] {
+    width: 100%;
+}
+
+.pan-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+}
+
+.dir-btn,
+.fmt-btn {
+    background: transparent;
+    border: 1px solid var(--border-color);
+    color: var(--text-light);
+    padding: 8px 10px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: var(--transition);
+}
+
+.dir-btn.active,
+.fmt-btn.active {
+    background: var(--primary-color);
+    border-color: var(--primary-color);
+    color: var(--white);
+}
+
+.format-select {
+    display: flex;
+    gap: 8px;
+}
+
+.video-result video {
+    margin-top: 20px;
+    width: 100%;
+    max-height: 500px;
+}


### PR DESCRIPTION
## Summary
- add collapsible Video panel with controls for duration, fps, bitrate, easing, direction, format and generate button
- implement canvas-based video renderer to create panning animation and export mp4/webm
- style video maker UI and add camera icon asset

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b34ee1b0e883338c4e0e570292fc82