### PR TITLE
Add customizable watermark support

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,6 +125,85 @@
                     </div>
                 </div>
 
+                <!-- Watermark Settings -->
+                <div class="watermark-maker" id="watermark-maker">
+                    <details>
+                        <summary class="watermark-summary">
+                            <span>Watermark</span>
+                        </summary>
+                        <div class="watermark-settings">
+                            <div class="setting">
+                                <label for="watermark-type">Type</label>
+                                <select id="watermark-type">
+                                    <option value="none">None</option>
+                                    <option value="text">Text</option>
+                                    <option value="image">Image</option>
+                                </select>
+                            </div>
+                            <div id="text-watermark-options" class="wm-option">
+                                <div class="setting">
+                                    <label for="wm-text">Content</label>
+                                    <input type="text" id="wm-text" placeholder="Watermark text">
+                                </div>
+                                <div class="setting">
+                                    <label for="wm-font-size">Font Size</label>
+                                    <input type="number" id="wm-font-size" value="24" min="1">
+                                </div>
+                                <div class="setting">
+                                    <label for="wm-font-weight">Font Weight</label>
+                                    <select id="wm-font-weight">
+                                        <option value="normal">Normal</option>
+                                        <option value="bold">Bold</option>
+                                        <option value="bolder">Bolder</option>
+                                    </select>
+                                </div>
+                                <div class="setting">
+                                    <label for="wm-color">Color</label>
+                                    <input type="color" id="wm-color" value="#ffffff">
+                                </div>
+                                <div class="setting">
+                                    <label for="wm-stroke-color">Stroke Color</label>
+                                    <input type="color" id="wm-stroke-color" value="#000000">
+                                </div>
+                                <div class="setting">
+                                    <label for="wm-stroke-width">Stroke Width</label>
+                                    <input type="number" id="wm-stroke-width" value="0" min="0">
+                                </div>
+                            </div>
+                            <div id="image-watermark-options" class="wm-option">
+                                <div class="setting">
+                                    <label for="wm-image">Watermark Image</label>
+                                    <input type="file" id="wm-image" accept="image/*">
+                                </div>
+                            </div>
+                            <div class="setting">
+                                <label for="wm-opacity">Opacity <span id="wm-opacity-value">100%</span></label>
+                                <input type="range" id="wm-opacity" min="0" max="100" value="100">
+                            </div>
+                            <div class="setting">
+                                <label>Position</label>
+                                <div id="wm-position-grid" class="position-grid">
+                                    <button type="button" class="pos-btn" data-pos="top-left"></button>
+                                    <button type="button" class="pos-btn" data-pos="top-center"></button>
+                                    <button type="button" class="pos-btn" data-pos="top-right"></button>
+                                    <button type="button" class="pos-btn" data-pos="middle-left"></button>
+                                    <button type="button" class="pos-btn" data-pos="center"></button>
+                                    <button type="button" class="pos-btn" data-pos="middle-right"></button>
+                                    <button type="button" class="pos-btn" data-pos="bottom-left"></button>
+                                    <button type="button" class="pos-btn" data-pos="bottom-center"></button>
+                                    <button type="button" class="pos-btn active" data-pos="bottom-right"></button>
+                                </div>
+                            </div>
+                            <div class="setting">
+                                <label for="wm-offset-x">Offset X</label>
+                                <input type="number" id="wm-offset-x" value="0">
+                                <label for="wm-offset-y">Offset Y</label>
+                                <input type="number" id="wm-offset-y" value="0">
+                            </div>
+                        </div>
+                    </details>
+                </div>
+
                 <!-- Pan Video Maker -->
                 <div class="video-maker" id="video-maker">
                     <details>

--- a/styles.css
+++ b/styles.css
@@ -856,3 +856,68 @@ footer {
     width: 100%;
     max-height: 500px;
 }
+
+/* Watermark settings */
+.watermark-maker {
+    margin-top: 40px;
+}
+
+.watermark-maker details {
+    background: var(--surface);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+}
+
+.watermark-summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 15px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 600;
+}
+
+.watermark-settings {
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.watermark-settings .setting label {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+
+.wm-option {
+    display: none;
+    margin-top: 10px;
+}
+
+.wm-option.active {
+    display: block;
+}
+
+.position-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 4px;
+}
+
+.pos-btn {
+    background: transparent;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    width: 32px;
+    height: 32px;
+    cursor: pointer;
+    transition: var(--transition);
+}
+
+.pos-btn.active {
+    background: var(--primary-color);
+    border-color: var(--primary-color);
+    color: var(--white);
+}


### PR DESCRIPTION
## Summary
- debounced watermark controls for smoother updates and reduced redundant canvas creation
- fixed slice storage and processing logic to avoid duplicate data URLs and double processing
- allowed non-PNG watermark images with a transparency tip and ensured full-view exports include watermarks

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3512e294c8333a4d305a8566cd126