### PR TITLE
Improve video generation feedback

### DIFF
--- a/script.js
+++ b/script.js
@@ -972,6 +972,10 @@ document.addEventListener('DOMContentLoaded', () => {
     async function generatePanVideo() {
         if (!originalImage) return;
 
+        // Provide feedback while rendering the video
+        showLoading('Generating video...');
+        if (generateVideoBtn) generateVideoBtn.disabled = true;
+
         const duration = Number(videoDuration.value);
         const fps = Number(videoFps.value);
         const bitrate = Number(videoBitrate.value) * 1000000;
@@ -989,6 +993,8 @@ document.addEventListener('DOMContentLoaded', () => {
         try {
             recorder = new MediaRecorder(stream, { mimeType, videoBitsPerSecond: bitrate });
         } catch (e) {
+            hideLoading();
+            if (generateVideoBtn) generateVideoBtn.disabled = false;
             alert('Video format not supported in this browser.');
             return;
         }
@@ -1009,6 +1015,8 @@ document.addEventListener('DOMContentLoaded', () => {
             link.textContent = 'Download Video';
             link.className = 'secondary-btn';
             videoResult.appendChild(link);
+            hideLoading();
+            if (generateVideoBtn) generateVideoBtn.disabled = false;
         };
 
         const scale = canvas.height / originalImage.height;


### PR DESCRIPTION
## Summary
- Disable Generate Video button while rendering
- Display a loading overlay during video creation and remove it when done

## Testing
- `node --check script.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b35602a63c8333bd82894ec208c913