### PR TITLE
Fix watermark selector and improve button states

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
             </header>
 
             <div id="error-message" class="toast">
-                <p>Please upload a panorama image with a horizontal aspect ratio (width > height).</p>
+                <p>Please upload a panorama image with a horizontal aspect ratio (width &gt; height).</p>
                 <button id="dismiss-error" class="secondary-btn">Dismiss</button>
             </div>
 
@@ -42,7 +42,7 @@
                 <h2>Preview</h2>
                 <div class="preview-wrapper">
                     <div class="image-preview">
-                        <img id="preview-img" src="" alt="Image preview">
+                        <img id="preview-img" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Image preview">
                     </div>
                     <div class="preview-info">
                         <div class="info-card">
@@ -62,7 +62,7 @@
                 <h2>Your Results</h2>
                 <div class="slices-preview" id="slices-preview"></div>
                 <div class="download-section">
-                    <button id="download-btn" class="primary-btn">
+                    <button id="download-btn" class="primary-btn" disabled>
                         <span class="btn-text">Download ZIP</span>
                         <span class="btn-loader"></span>
                     </button>
@@ -83,7 +83,7 @@
                         <span class="toggle-label">High Resolution Mode</span>
                     </label>
                     <p class="toggle-description">Uses maximum possible resolution from your image</p>
-                    <button id="process-btn" class="primary-btn full-width">Generate Slices</button>
+                    <button id="process-btn" class="primary-btn full-width" disabled>Generate Slices</button>
                 </div>
             </details>
 
@@ -233,7 +233,7 @@
                         </div>
                     </div>
                     <div class="actions">
-                        <button id="generate-video" class="primary-btn full-width">Generate Video</button>
+                        <button id="generate-video" class="primary-btn full-width" disabled>Generate Video</button>
                     </div>
                 </div>
             </details>

--- a/script.js
+++ b/script.js
@@ -38,7 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const formatButtons = document.querySelectorAll('#video-format .fmt-btn');
     const generateVideoBtn = document.getElementById('generate-video');
     const videoResult = document.getElementById('video-result');
-    const watermarkType = document.getElementById('watermark-type');
+    const watermarkType = document.getElementById('wm-type');
     const wmTextInput = document.getElementById('wm-text');
     const wmFontSize = document.getElementById('wm-font-size');
     const wmFontWeight = document.getElementById('wm-font-weight');
@@ -53,6 +53,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const wmOffsetY = document.getElementById('wm-offset-y');
     const textWatermarkOptions = document.getElementById('text-watermark-options');
     const imageWatermarkOptions = document.getElementById('image-watermark-options');
+
+    // Disable actions until a valid image is loaded
+    processBtn.disabled = true;
+    downloadBtn.disabled = true;
+    if (generateVideoBtn) generateVideoBtn.disabled = true;
     
     // Variables to store image data
     let originalImage = null;
@@ -578,6 +583,11 @@ document.addEventListener('DOMContentLoaded', () => {
                     colorPicker.value = backgroundSettings.color;
                 }
 
+                // Enable processing now that a valid image is loaded
+                processBtn.disabled = false;
+                downloadBtn.disabled = true;
+                if (generateVideoBtn) generateVideoBtn.disabled = false;
+
                 // Update image details
                 updateImageDetails();
 
@@ -890,6 +900,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         
         resultContainer.style.display = 'block';
+        downloadBtn.disabled = false;
         window.scrollTo({
             top: resultContainer.offsetTop - 20,
             behavior: 'smooth'
@@ -905,9 +916,12 @@ document.addEventListener('DOMContentLoaded', () => {
         previewContainer.style.display = 'none';
         resultContainer.style.display = 'none';
         errorMessage.classList.remove('active');
-        
+
         // Show upload area
         uploadArea.style.display = 'block';
+        processBtn.disabled = true;
+        downloadBtn.disabled = true;
+        if (generateVideoBtn) generateVideoBtn.disabled = true;
         
         // Clear image data
         originalImage = null;


### PR DESCRIPTION
## Summary
- Correct watermark type selector to match HTML
- Disable processing, download and video buttons until a valid image loads
- Provide placeholder preview image and escape special chars to satisfy HTML lint

## Testing
- `node --check script.js`
- `npx --yes htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_68b35be28e1c8333a0a3370646b14476